### PR TITLE
Small Modifications on SOMotionDetector

### DIFF
--- a/BackgroundGeolocation/MAURActivityLocationProvider.m
+++ b/BackgroundGeolocation/MAURActivityLocationProvider.m
@@ -65,7 +65,7 @@ static NSString * const Domain = @"com.marianhello";
     locationManager.distanceFilter = config.distanceFilter.integerValue; // meters
     locationManager.desiredAccuracy = [config decodeDesiredAccuracy];
     [SOMotionDetector sharedInstance].activityDetectionInterval = config.activitiesInterval.intValue / 1000;
-    
+    [SOMotionDetector sharedInstance].useMotionDetectorOnly = [config useMotionDetectorOnly];
     return YES;
 }
 

--- a/BackgroundGeolocation/MAURConfig.h
+++ b/BackgroundGeolocation/MAURConfig.h
@@ -36,6 +36,7 @@ enum {
 @property NSNumber *_pauseLocationUpdates;
 @property NSNumber *locationProvider;
 @property NSObject *_template;
+@property NSNumber *_useMotionDetectorOnly;
 
 - (instancetype) initWithDefaults;
 + (instancetype) fromDictionary:(NSDictionary*)config;
@@ -64,6 +65,7 @@ enum {
 - (BOOL) stopOnTerminate;
 - (BOOL) saveBatteryOnBackground;
 - (BOOL) pauseLocationUpdates;
+- (BOOL) useMotionDetectorOnly;
 - (CLActivityType) decodeActivityType;
 - (NSInteger) decodeDesiredAccuracy;
 - (NSString*) getHttpHeadersAsString:(NSError * __autoreleasing *)outError;

--- a/BackgroundGeolocation/MAURConfig.m
+++ b/BackgroundGeolocation/MAURConfig.m
@@ -10,9 +10,9 @@
 #define isNull(value) (value == nil || value == (id)[NSNull null])
 #define isNotNull(value) (value != nil && value != (id)[NSNull null])
 
-@implementation MAURConfig 
+@implementation MAURConfig
 
-@synthesize stationaryRadius, distanceFilter, desiredAccuracy, _debug, activityType, activitiesInterval, _stopOnTerminate, url, syncUrl, syncThreshold, httpHeaders, _saveBatteryOnBackground, maxLocations, _pauseLocationUpdates, locationProvider, _template;
+@synthesize stationaryRadius, distanceFilter, desiredAccuracy, _debug, activityType, activitiesInterval, _stopOnTerminate, url, syncUrl, syncThreshold, httpHeaders, _saveBatteryOnBackground, maxLocations, _pauseLocationUpdates, locationProvider, _template, _useMotionDetectorOnly;
 
 -(instancetype) initWithDefaults {
     self = [super init];
@@ -33,6 +33,7 @@
     syncThreshold = [NSNumber numberWithInt:100];
     _pauseLocationUpdates = [NSNumber numberWithBool:NO];
     locationProvider = [NSNumber numberWithInt:DISTANCE_FILTER_PROVIDER];
+    _useMotionDetectorOnly = [NSNumber numberWithBool:NO];
 //    template =
     
     return self;
@@ -90,7 +91,9 @@
     if (config[@"postTemplate"] != nil) {
         instance._template = config[@"postTemplate"];
     }
-
+    if (config[@"useMotionDetectorOnly"] != nil) {
+        instance._useMotionDetectorOnly = config[@"useMotionDetectorOnly"];
+    }
     return instance;
 }
 
@@ -154,7 +157,10 @@
     if ([newConfig hasTemplate]) {
         merger._template = newConfig._template;
     }
-
+    if ([newConfig useMotionDetectorOnly]) {
+        merger._useMotionDetectorOnly = newConfig._useMotionDetectorOnly;
+    }
+    
     return merger;
 }
 
@@ -178,6 +184,7 @@
         copy._pauseLocationUpdates = _pauseLocationUpdates;
         copy.locationProvider = locationProvider;
         copy._template = _template;
+        copy._useMotionDetectorOnly = _useMotionDetectorOnly;
     }
     
     return copy;
@@ -358,6 +365,11 @@
 - (BOOL) pauseLocationUpdates
 {
     return _pauseLocationUpdates.boolValue;
+}
+
+- (BOOL) useMotionDetectorOnly
+{
+    return _useMotionDetectorOnly.boolValue;
 }
 
 - (CLActivityType) decodeActivityType

--- a/BackgroundGeolocation/SOMotionDetector/SOMotionDetector.h
+++ b/BackgroundGeolocation/SOMotionDetector/SOMotionDetector.h
@@ -76,6 +76,11 @@
 @property (nonatomic) double activityDetectionInterval;
 
 /**
+ * Controls whether whether additional motion calculation will be used for identifying a motion
+ */
+@property (nonatomic) BOOL useMotionDetectorOnly;
+
+/**
  *@param speed  The minimum speed value less than which will be considered as not moving state
  */
 - (void)setMinimumSpeed:(CGFloat)speed;

--- a/BackgroundGeolocation/SOMotionDetector/SOMotionDetector.m
+++ b/BackgroundGeolocation/SOMotionDetector/SOMotionDetector.m
@@ -37,6 +37,7 @@ CGFloat kMinimumRunningAcceleration = 3.5f;
 
 @property (strong, nonatomic) CLLocation *currentLocation;
 @property (nonatomic) SOMotionType previousMotionType;
+@property (nonatomic) int previousMotionConfidence;
 
 #pragma mark - Accelerometer manager
 @property (strong, nonatomic) CMMotionManager *motionManager;
@@ -149,9 +150,12 @@ CGFloat kMinimumRunningAcceleration = 3.5f;
                 _motionActivity.motionType = motionType;
                 _motionActivity.confidence = activity.confidence;
                 
+                BOOL higherConfience = (motionType == self.previousMotionType && activity.confidence > self.previousMotionConfidence ? YES : NO);
+                
                 // If type was changed, then call delegate method
-                if (motionType != self.previousMotionType) {
+                if (motionType != self.previousMotionType || higherConfience) {
                     self.previousMotionType = motionType;
+                    self.previousMotionConfidence = activity.confidence;
                     if (self.delegate && [self.delegate respondsToSelector:@selector(motionDetector:activityTypeChanged:)]) {
                         [self.delegate motionDetector:self activityTypeChanged:self.motionActivity];
                     }

--- a/BackgroundGeolocation/SOMotionDetector/SOMotionDetector.m
+++ b/BackgroundGeolocation/SOMotionDetector/SOMotionDetector.m
@@ -43,7 +43,6 @@ CGFloat kMinimumRunningAcceleration = 3.5f;
 @property (strong, nonatomic) CMMotionManager *motionManager;
 @property (strong, nonatomic) CMMotionActivityManager *motionActivityManager;
 
-
 @end
 
 @implementation SOMotionDetector
@@ -98,7 +97,9 @@ CGFloat kMinimumRunningAcceleration = 3.5f;
                                              withHandler:^(CMAccelerometerData *accelerometerData, NSError *error)
      {
          _acceleration = accelerometerData.acceleration;
-         [self calculateMotionType];
+        if (!self.useMotionDetectorOnly) {
+            [self calculateMotionType];
+        }
          dispatch_async(dispatch_get_main_queue(), ^{
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -132,19 +133,6 @@ CGFloat kMinimumRunningAcceleration = 3.5f;
                     motionType = MotionTypeNotMoving;
                 } else {
                     motionType = MotionTypeUnknown;
-                }
-                
-                int confidence;
-                switch (activity.confidence) {
-                    case CMMotionActivityConfidenceLow:
-                        confidence = 20;
-                        break;
-                    case CMMotionActivityConfidenceMedium:
-                        confidence = 40;
-                        break;
-                    case CMMotionActivityConfidenceHigh:
-                        confidence = 80;
-                        break;
                 }
 
                 _motionActivity.motionType = motionType;
@@ -309,7 +297,9 @@ CGFloat kMinimumRunningAcceleration = 3.5f;
         }
     });
 
-    [self calculateMotionType];
+    if (!self.useMotionDetectorOnly) {
+        [self calculateMotionType];
+    }
 }
 
 #pragma mark - LocationManager notification handler


### PR DESCRIPTION
- Added a flag, `useMotionDetectorOnly`, to control `calculateMotionType` method<br/>
The `calculateMotionType` method is triggered in the acceleration and location change handler. This method takes the current moving speed detected by the sensor to predict the motion activity. <br/>
In practice, the motion prediction produced by the method seems pretty inaccurate. What's worse, the method always overwrites the more accurate motion activity produced by the native activity motion detector API - `CMMotion​Activity`, without taking the confidence level into account at all.<br/>
It would make more sense to call `calculateMotionType` when `CMMotion​Activity` detects an `UNKNOWN` activity or when `CMMotion​Activity` detects activity with a confidence level of 0. <br/>
For simplicity, I chose to disable the function call for now because the activity detected by the vanilla `CMMotion​Activity` is good enough for our use cause. 

- Added a field, `previousMotionConfidence ` to keep the confidence level <br/>
The field is used for storing the confidence level of the previous activity. If the activity is the same and has a lower or equal confidence level, then there is no need to trigger an activity event. 

- Removed unused confidence switch statement